### PR TITLE
Fix curses draws over terminal when suspended

### DIFF
--- a/tg/controllers/__init__.py
+++ b/tg/controllers/__init__.py
@@ -133,7 +133,7 @@ class Controller:
                 msg = self.view.get_input()
                 if msg:
                     self.model.send_message(text=msg)
-                    self.view.draw_status(f"Sent: {msg}")
+                    self.view.status.draw(f"Sent: {msg}")
 
             elif keys in ("h", "^D"):
                 return "BACK"
@@ -184,17 +184,17 @@ class Controller:
         with self.lock:
             # using lock here, because refresh_chats is used from another
             # thread by tdlib python wrapper
-            self.view.draw_chats(
+            self.view.chats.draw(
                 self.model.current_chat,
                 self.model.get_chats(limit=self.view.chats.h),
             )
             self.refresh_msgs()
-            self.view.draw_status()
+            self.view.status.draw()
 
     def refresh_msgs(self) -> None:
         self.view.msgs.users = self.model.users
         msgs = self.model.fetch_msgs(limit=self.view.msgs.h)
-        self.view.draw_msgs(self.model.get_current_chat_msg(), msgs)
+        self.view.msgs.draw(self.model.get_current_chat_msg(), msgs)
 
     @handle_exception
     def update_new_msg(self, update):

--- a/tg/utils.py
+++ b/tg/utils.py
@@ -69,9 +69,12 @@ class suspend:
         subprocess.call(cmd, shell=True)
 
     def __enter__(self):
+        for view in (self.view.chats, self.view.msgs, self.view.status):
+            view._refresh = view.win.noutrefresh
         curses.endwin()
         return self
 
     def __exit__(self, exc_type, exc_val, tb):
-        # works without it, actually
+        for view in (self.view.chats, self.view.msgs, self.view.status):
+            view._refresh = view.win.refresh
         curses.doupdate()


### PR DESCRIPTION
This patch fixes the problem when you are listening voice throug mpv or watching beautiful pics in terminal through icat or something and new event (msg) comes. It triggers refresh, which forces curses to draw over current terminal. Instead, we should call noutrefresh(), it will refresh window in the internal buffer but will not trigger curses.doupdate(), so the scrren will not be updated. FYI: refresh() does exactly this, it calls noutrefresh() and then curses.doupdate()

Also, removed some useless abstraction, like calling draw to call msgs.draw.