### PR TITLE
Fix filling lower right corner is curses

### DIFF
--- a/tg/views.py
+++ b/tg/views.py
@@ -393,17 +393,24 @@ class MsgView:
             for attr, elem in zip(self._msg_attributes(selected), elements):
                 if not elem:
                     continue
-                full_line = self.w - column - len(elem) == 0
-                last_line = self.h - 1 == line_num
+                lines = (column + len(elem)) // self.w
+                last_line = self.h == line_num + lines
                 # work around agaist curses behaviour, when you cant write
                 # char to the lower right coner of the window
                 # see https://stackoverflow.com/questions/21594778/how-to-fill-to-lower-right-corner-in-python-curses/27517397#27517397
-                if full_line and last_line:
-                    # insstr does not wraps long strings
-                    draw_func = self.win.insstr
+                if last_line:
+                    start, stop = 0, self.w - column
+                    for i in range(lines):
+                        # insstr does not wraps long strings
+                        self.win.insstr(
+                            line_num + i,
+                            column if not i else 0,
+                            elem[start:stop],
+                            attr,
+                        )
+                        start, stop = stop, stop + self.w
                 else:
-                    draw_func = self.win.addstr
-                draw_func(line_num, column, elem, attr)
+                    self.win.addstr(line_num, column, elem, attr)
                 column += len(elem)
 
         self._refresh()

--- a/tg/views.py
+++ b/tg/views.py
@@ -393,7 +393,17 @@ class MsgView:
             for attr, elem in zip(self._msg_attributes(selected), elements):
                 if not elem:
                     continue
-                self.win.addstr(line_num, column, elem, attr)
+                full_line = self.w - column - len(elem) == 0
+                last_line = self.h - 1 == line_num
+                # work around agaist curses behaviour, when you cant write
+                # char to the lower right coner of the window
+                # see https://stackoverflow.com/questions/21594778/how-to-fill-to-lower-right-corner-in-python-curses/27517397#27517397
+                if full_line and last_line:
+                    # insstr does not wraps long strings
+                    draw_func = self.win.insstr
+                else:
+                    draw_func = self.win.addstr
+                draw_func(line_num, column, elem, attr)
                 column += len(elem)
 
         self._refresh()


### PR DESCRIPTION
Curses can't write to lower right conner of the window, see
- https://stackoverflow.com/questions/21594778/how-to-fill-to-lower-right-corner-in-python-curses/27517397#27517397
- https://stackoverflow.com/questions/36387625/curses-fails-when-calling-addch-on-the-bottom-right-corner/36389815
- https://docs.python.org/3/library/curses.html#curses.window.addstr