### PR TITLE
Introduce top status panel

### DIFF
--- a/tg/controllers.py
+++ b/tg/controllers.py
@@ -2,7 +2,6 @@ import curses
 import logging
 import os
 import shlex
-import threading
 from datetime import datetime
 from functools import partial, wraps
 from queue import Queue
@@ -12,12 +11,11 @@ from typing import Any, Callable, Dict, List, Optional
 from tg import config
 from tg.models import Model
 from tg.msg import MsgProxy
-from tg.tdlib import Tdlib
+from tg.tdlib import Action, Tdlib
 from tg.utils import (
     get_duration,
     get_video_resolution,
     get_waveform,
-    handle_exception,
     is_yes,
     notify,
     suspend,
@@ -238,10 +236,13 @@ class Controller:
         if not self.can_send_msg():
             self.present_info("Can't send msg in this chat")
             return
+        chat_id = self.model.chats.id_by_index(self.model.current_chat)
+        self.tg.send_chat_action(chat_id, Action.chatActionTyping)
         if msg := self.view.status.get_input():
             self.model.send_message(text=msg)
             self.present_info("Message sent")
         else:
+            self.tg.send_chat_action(chat_id, Action.chatActionCancel)
             self.present_info("Message wasn't sent")
 
     @bind(msg_handler, ["A", "I"])
@@ -252,11 +253,16 @@ class Controller:
         with NamedTemporaryFile("r+", suffix=".txt") as f, suspend(
             self.view
         ) as s:
+            chat_id = self.model.chats.id_by_index(self.model.current_chat)
+            self.tg.send_chat_action(chat_id, Action.chatActionTyping)
             s.call(config.LONG_MSG_CMD.format(file_path=shlex.quote(f.name)))
             with open(f.name) as f:
                 if msg := f.read().strip():
                     self.model.send_message(text=msg)
                     self.present_info("Message sent")
+                else:
+                    self.tg.send_chat_action(chat_id, Action.chatActionCancel)
+                    self.present_info("Message wasn't sent")
 
     @bind(msg_handler, ["sv"])
     def send_video(self):
@@ -543,14 +549,14 @@ class Controller:
         self.queue.put(self._render_chats)
 
     def _render_chats(self) -> None:
-        page_size = self.view.chats.h
+        page_size = self.view.chats.h - 1
         chats = self.model.get_chats(
             self.model.current_chat, page_size, MSGS_LEFT_SCROLL_THRESHOLD
         )
         selected_chat = min(
             self.model.current_chat, page_size - MSGS_LEFT_SCROLL_THRESHOLD
         )
-        self.view.chats.draw(selected_chat, chats)
+        self.view.chats.draw(selected_chat, chats, self.model.chats.title)
 
     def render_msgs(self) -> None:
         self.queue.put(self._render_msgs)
@@ -561,10 +567,13 @@ class Controller:
             return
         msgs = self.model.fetch_msgs(
             current_position=current_msg_idx,
-            page_size=self.view.msgs.h,
+            page_size=self.view.msgs.h - 1,
             msgs_left_scroll_threshold=MSGS_LEFT_SCROLL_THRESHOLD,
         )
-        self.view.msgs.draw(current_msg_idx, msgs, MSGS_LEFT_SCROLL_THRESHOLD)
+        chat = self.model.chats.chats[self.model.current_chat]
+        self.view.msgs.draw(
+            current_msg_idx, msgs, MSGS_LEFT_SCROLL_THRESHOLD, chat
+        )
 
     def notify_for_message(self, chat_id: int, msg: MsgProxy):
         # do not notify, if muted

--- a/tg/controllers.py
+++ b/tg/controllers.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional
 from tg import config
 from tg.models import Model
 from tg.msg import MsgProxy
-from tg.tdlib import Action, Tdlib
+from tg.tdlib import ChatAction, Tdlib
 from tg.utils import (
     get_duration,
     get_video_resolution,
@@ -237,12 +237,12 @@ class Controller:
             self.present_info("Can't send msg in this chat")
             return
         chat_id = self.model.chats.id_by_index(self.model.current_chat)
-        self.tg.send_chat_action(chat_id, Action.chatActionTyping)
+        self.tg.send_chat_action(chat_id, ChatAction.chatActionTyping)
         if msg := self.view.status.get_input():
             self.model.send_message(text=msg)
             self.present_info("Message sent")
         else:
-            self.tg.send_chat_action(chat_id, Action.chatActionCancel)
+            self.tg.send_chat_action(chat_id, ChatAction.chatActionCancel)
             self.present_info("Message wasn't sent")
 
     @bind(msg_handler, ["A", "I"])
@@ -254,14 +254,16 @@ class Controller:
             self.view
         ) as s:
             chat_id = self.model.chats.id_by_index(self.model.current_chat)
-            self.tg.send_chat_action(chat_id, Action.chatActionTyping)
+            self.tg.send_chat_action(chat_id, ChatAction.chatActionTyping)
             s.call(config.LONG_MSG_CMD.format(file_path=shlex.quote(f.name)))
             with open(f.name) as f:
                 if msg := f.read().strip():
                     self.model.send_message(text=msg)
                     self.present_info("Message sent")
                 else:
-                    self.tg.send_chat_action(chat_id, Action.chatActionCancel)
+                    self.tg.send_chat_action(
+                        chat_id, ChatAction.chatActionCancel
+                    )
                     self.present_info("Message wasn't sent")
 
     @bind(msg_handler, ["sv"])

--- a/tg/models.py
+++ b/tg/models.py
@@ -547,12 +547,14 @@ class UserModel:
         self.users[user_id] = result.update
         return result.update
 
-    def get_group_info(self, group_id: int) -> None:
+    def get_group_info(self, group_id: int) -> Optional[Dict[str, Any]]:
         if group_id in self.groups:
             return self.groups[group_id]
         self.tg.get_basic_group(group_id)
+        return None
 
-    def get_supergroup_info(self, supergroup_id):
+    def get_supergroup_info(self, supergroup_id: int) -> Optional[Dict[str, Any]]:
         if supergroup_id in self.supergroups:
             return self.supergroups[supergroup_id]
         self.tg.get_supergroup(supergroup_id)
+        return None

--- a/tg/models.py
+++ b/tg/models.py
@@ -547,7 +547,7 @@ class UserModel:
         self.users[user_id] = result.update
         return result.update
 
-    def get_group_info(self, group_id):
+    def get_group_info(self, group_id: int):
         if group_id in self.groups:
             return self.groups[group_id]
         self.tg.get_basic_group(group_id)

--- a/tg/models.py
+++ b/tg/models.py
@@ -553,7 +553,9 @@ class UserModel:
         self.tg.get_basic_group(group_id)
         return None
 
-    def get_supergroup_info(self, supergroup_id: int) -> Optional[Dict[str, Any]]:
+    def get_supergroup_info(
+        self, supergroup_id: int
+    ) -> Optional[Dict[str, Any]]:
         if supergroup_id in self.supergroups:
             return self.supergroups[supergroup_id]
         self.tg.get_supergroup(supergroup_id)

--- a/tg/models.py
+++ b/tg/models.py
@@ -547,7 +547,7 @@ class UserModel:
         self.users[user_id] = result.update
         return result.update
 
-    def get_group_info(self, group_id: int):
+    def get_group_info(self, group_id: int) -> None:
         if group_id in self.groups:
             return self.groups[group_id]
         self.tg.get_basic_group(group_id)

--- a/tg/models.py
+++ b/tg/models.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from tg.msg import MsgProxy
-from tg.tdlib import Tdlib
+from tg.tdlib import Action, Tdlib
 from tg.utils import copy_to_clipboard
 
 log = logging.getLogger(__name__)
@@ -126,6 +126,8 @@ class Model:
         limit = offset + page_size
         return self.chats.fetch_chats(offset=offset, limit=limit)
 
+    # def send_action(self, action: Action)
+
     def send_message(self, text: str) -> bool:
         chat_id = self.chats.id_by_index(self.current_chat)
         if chat_id is None:
@@ -206,6 +208,7 @@ class ChatModel:
         self.chats: List[Dict[str, Any]] = []
         self.chat_ids: List[int] = []
         self.have_full_chat_list = False
+        self.title: str = "Chats"
 
     def id_by_index(self, index: int) -> Optional[int]:
         if index >= len(self.chats):
@@ -474,6 +477,9 @@ class UserModel:
         self.tg = tg
         self.me = None
         self.users: Dict[int, Dict] = {}
+        self.groups: Dict[int, Dict] = {}
+        self.supergroups: Dict[int, Dict] = {}
+        self.actions: Dict[int, Dict] = {}
         self.not_found: Set[int] = set()
 
     def get_me(self):
@@ -487,10 +493,38 @@ class UserModel:
         self.me = result.update
         return self.me
 
+    def get_action(self, chat_id: int) -> Optional[str]:
+        action = self.actions.get(chat_id)
+        if action is None:
+            return None
+        action_type = action["action"]["@type"]
+        try:
+            return Action[action_type].value + "..."
+        except KeyError:
+            log.error(f"Action type {action_type} not implemented")
+        return None
+
     def set_status(self, user_id: int, status: Dict[str, Any]):
         if user_id not in self.users:
             self.get_user(user_id)
         self.users[user_id]["status"] = status
+
+    def get_status(self, user_id: int):
+        if user_id not in self.users:
+            return None
+        user_status = self.users[user_id]["status"]
+        log.info(f"user_status:: {user_status}")
+        status = self.statuses.get(user_status["@type"])
+        if status == "online":
+            expires = user_status["expires"]
+            if expires < time.time():
+                return None
+            return status
+        elif status == "offline":
+            was_online = user_status["was_online"]
+            ago = pretty_ts(was_online)
+            return f"last seen {ago}"
+        return f"last seen {status}"
 
     def is_online(self, user_id: int):
         user = self.get_user(user_id)
@@ -516,3 +550,48 @@ class UserModel:
             return {}
         self.users[user_id] = result.update
         return result.update
+
+    def get_group_info(self, group_id):
+        if group_id in self.groups:
+            return self.groups[group_id]
+        self.tg.get_basic_group(group_id)
+
+    def get_supergroup_info(self, supergroup_id):
+        if supergroup_id in self.supergroups:
+            return self.supergroups[supergroup_id]
+        self.tg.get_supergroup(supergroup_id)
+
+
+def pretty_ts(ts):
+    from datetime import datetime
+
+    now = datetime.now()
+    diff = now - datetime.fromtimestamp(ts)
+    second_diff = diff.seconds
+    day_diff = diff.days
+
+    if day_diff < 0:
+        return ""
+
+    if day_diff == 0:
+        if second_diff < 10:
+            return "just now"
+        if second_diff < 60:
+            return f"{second_diff} seconds ago"
+        if second_diff < 120:
+            return "a minute ago"
+        if second_diff < 3600:
+            return f"{int(second_diff / 60)} minutes ago"
+        if second_diff < 7200:
+            return "an hour ago"
+        if second_diff < 86400:
+            return f"{int(second_diff / 3600)} hours ago"
+    if day_diff == 1:
+        return "Yesterday"
+    if day_diff < 7:
+        return f"{day_diff} days ago"
+    if day_diff < 31:
+        return f"{int(day_diff / 7)} weeks ago"
+    if day_diff < 365:
+        return f"{int(day_diff / 30)} months ago"
+    return f"{int(day_diff / 365)} years ago"

--- a/tg/tdlib.py
+++ b/tg/tdlib.py
@@ -4,20 +4,37 @@ from typing import Any, Dict, List
 from telegram.client import AsyncResult, Telegram
 
 
-class Action(Enum):
+class ChatAction(Enum):
     chatActionTyping = "typing"
     chatActionCancel = "cancel"
     chatActionRecordingVideo = "recording video"
     chatActionUploadingVideo = "uploading video"
-    chatActionRecordingVoiceNote = "recording voice note"
-    chatActionUploadingVoiceNote = "uploading voice note"
+    chatActionRecordingVoiceNote = "recording voice"
+    chatActionUploadingVoiceNote = "uploading voice"
     chatActionUploadingPhoto = "uploading photo"
     chatActionUploadingDocument = "uploading document"
     chatActionChoosingLocation = "choosing location"
     chatActionChoosingContact = "choosing contact"
     chatActionStartPlayingGame = "start playing game"
-    chatActionRecordingVideoNote = "recording video note"
-    chatActionUploadingVideoNote = "uploading video note"
+    chatActionRecordingVideoNote = "recording video"
+    chatActionUploadingVideoNote = "uploading video"
+
+
+class ChatType(Enum):
+    chatTypePrivate = "private"
+    chatTypeBasicGroup = "group"
+    chatTypeSupergroup = "supergroup"
+    channel = "channel"
+    chatTypeSecret = "secret"
+
+
+class UserStatus(Enum):
+    userStatusEmpty = ""
+    userStatusOnline = "online"
+    userStatusOffline = "offline"
+    userStatusRecently = "recently"
+    userStatusLastWeek = "last week"
+    userStatusLastMonth = "last month"
 
 
 class Tdlib(Telegram):
@@ -221,7 +238,7 @@ class Tdlib(Telegram):
         return self._send_data(data)
 
     def send_chat_action(
-        self, chat_id: int, action: Action, progress: int = None
+        self, chat_id: int, action: ChatAction, progress: int = None
     ) -> AsyncResult:
         data = {
             "@type": "sendChatAction",

--- a/tg/tdlib.py
+++ b/tg/tdlib.py
@@ -1,6 +1,23 @@
+from enum import Enum
 from typing import Any, Dict, List
 
 from telegram.client import AsyncResult, Telegram
+
+
+class Action(Enum):
+    chatActionTyping = "typing"
+    chatActionCancel = "cancel"
+    chatActionRecordingVideo = "recording video"
+    chatActionUploadingVideo = "uploading video"
+    chatActionRecordingVoiceNote = "recording voice note"
+    chatActionUploadingVoiceNote = "uploading voice note"
+    chatActionUploadingPhoto = "uploading photo"
+    chatActionUploadingDocument = "uploading document"
+    chatActionChoosingLocation = "choosing location"
+    chatActionChoosingContact = "choosing contact"
+    chatActionStartPlayingGame = "start playing game"
+    chatActionRecordingVideoNote = "recording video note"
+    chatActionUploadingVideoNote = "uploading video note"
 
 
 class Tdlib(Telegram):
@@ -186,5 +203,29 @@ class Tdlib(Telegram):
             "send_copy": send_copy,
             "remove_caption": remove_caption,
             "options": options,
+        }
+        return self._send_data(data)
+
+    def get_basic_group(self, basic_group_id: int,) -> AsyncResult:
+        data = {
+            "@type": "getBasicGroup",
+            "basic_group_id": basic_group_id,
+        }
+        return self._send_data(data)
+
+    def get_supergroup(self, supergroup_id: int,) -> AsyncResult:
+        data = {
+            "@type": "getSupergroup",
+            "supergroup_id": supergroup_id,
+        }
+        return self._send_data(data)
+
+    def send_chat_action(
+        self, chat_id: int, action: Action, progress: int = None
+    ) -> AsyncResult:
+        data = {
+            "@type": "sendChatAction",
+            "chat_id": chat_id,
+            "action": {"@type": action.name, "progress": progress},
         }
         return self._send_data(data)

--- a/tg/update_handlers.py
+++ b/tg/update_handlers.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from functools import wraps
 from typing import Any, Callable, Dict
 
@@ -77,7 +76,6 @@ def update_new_message(controller: Controller, update: Dict[str, Any]):
 
 @update_handler("updateChatOrder")
 def update_chat_order(controller: Controller, update: Dict[str, Any]):
-    log.info("Proccessing updateChatOrder")
     current_chat_id = controller.model.current_chat_id
     chat_id = update["chat_id"]
     order = update["order"]
@@ -88,7 +86,6 @@ def update_chat_order(controller: Controller, update: Dict[str, Any]):
 
 @update_handler("updateChatTitle")
 def update_chat_title(controller: Controller, update: Dict[str, Any]):
-    log.info("Proccessing updateChatTitle")
     chat_id = update["chat_id"]
     title = update["title"]
 
@@ -101,7 +98,6 @@ def update_chat_title(controller: Controller, update: Dict[str, Any]):
 def update_chat_is_marked_as_unread(
     controller: Controller, update: Dict[str, Any]
 ):
-    log.info("Proccessing updateChatIsMarkedAsUnread")
     chat_id = update["chat_id"]
     is_marked_as_unread = update["is_marked_as_unread"]
 
@@ -114,7 +110,6 @@ def update_chat_is_marked_as_unread(
 
 @update_handler("updateChatIsPinned")
 def update_chat_is_pinned(controller: Controller, update: Dict[str, Any]):
-    log.info("Proccessing updateChatIsPinned")
     chat_id = update["chat_id"]
     is_pinned = update["is_pinned"]
     order = update["order"]
@@ -128,7 +123,6 @@ def update_chat_is_pinned(controller: Controller, update: Dict[str, Any]):
 
 @update_handler("updateChatReadOutbox")
 def update_chat_read_outbox(controller: Controller, update: Dict[str, Any]):
-    log.info("Proccessing updateChatReadOutbox")
     chat_id = update["chat_id"]
     last_read_outbox_message_id = update["last_read_outbox_message_id"]
 
@@ -141,7 +135,6 @@ def update_chat_read_outbox(controller: Controller, update: Dict[str, Any]):
 
 @update_handler("updateChatReadInbox")
 def update_chat_read_inbox(controller: Controller, update: Dict[str, Any]):
-    log.info("Proccessing updateChatReadInbox")
     chat_id = update["chat_id"]
     last_read_inbox_message_id = update["last_read_inbox_message_id"]
     unread_count = update["unread_count"]
@@ -157,7 +150,6 @@ def update_chat_read_inbox(controller: Controller, update: Dict[str, Any]):
 
 @update_handler("updateChatDraftMessage")
 def update_chat_draft_message(controller: Controller, update: Dict[str, Any]):
-    log.info("Proccessing updateChatDraftMessage")
     chat_id = update["chat_id"]
     # FIXME: ignoring draft message itself for now because UI can't show it
     # draft_message = update["draft_message"]
@@ -170,7 +162,6 @@ def update_chat_draft_message(controller: Controller, update: Dict[str, Any]):
 
 @update_handler("updateChatLastMessage")
 def update_chat_last_message(controller: Controller, update: Dict[str, Any]):
-    log.info("Proccessing updateChatLastMessage")
     chat_id = update["chat_id"]
     last_message = update.get("last_message")
     if not last_message:
@@ -188,7 +179,6 @@ def update_chat_last_message(controller: Controller, update: Dict[str, Any]):
 
 @update_handler("updateChatNotificationSettings")
 def update_chat_notification_settings(controller: Controller, update):
-    log.info("Proccessing update_chat_notification_settings")
     chat_id = update["chat_id"]
     notification_settings = update["notification_settings"]
     if controller.model.chats.update_chat(
@@ -211,7 +201,6 @@ def update_message_send_succeeded(controller: Controller, update):
 
 @update_handler("updateFile")
 def update_file(controller: Controller, update):
-    log.info("update_file: %s", update)
     file_id = update["file"]["id"]
     local = update["file"]["local"]
     chat_id, msg_id = controller.model.downloads.get(file_id, (None, None))
@@ -252,13 +241,13 @@ def update_delete_messages(controller: Controller, update: Dict[str, Any]):
 
 @update_handler("updateConnectionState")
 def update_connection_state(controller: Controller, update: Dict[str, Any]):
-    log.info("state:: %s", update)
     state = update["state"]["@type"]
     states = {
         "connectionStateWaitingForNetwork": "Waiting for network...",
         "connectionStateConnectingToProxy": "Connecting to proxy...",
         "connectionStateConnecting": "Connecting...",
         "connectionStateUpdating": "Updating...",
+        # state exists, but when it's "Ready" we want to show "Chats"
         # "connectionStateReady": "Ready",
     }
     controller.model.chats.title = states.get(state, "Chats")
@@ -287,7 +276,6 @@ def update_supergroup(controller: Controller, update: Dict[str, Any]):
 
 @update_handler("updateUserChatAction")
 def update_user_chat_action(controller: Controller, update: Dict[str, Any]):
-    log.info("typing:: %s", update)
     chat_id = update["chat_id"]
     if update["action"]["@type"] == "chatActionCancel":
         controller.model.users.actions.pop(chat_id, None)

--- a/tg/utils.py
+++ b/tg/utils.py
@@ -218,7 +218,7 @@ def set_shorter_esc_delay(delay=25):
     os.environ.setdefault("ESCDELAY", str(delay))
 
 
-def pretty_ts(ts):
+def pretty_ts(ts: int):
     now = datetime.utcnow()
     diff = now - datetime.utcfromtimestamp(ts)
     second_diff = diff.seconds

--- a/tg/utils.py
+++ b/tg/utils.py
@@ -218,7 +218,7 @@ def set_shorter_esc_delay(delay=25):
     os.environ.setdefault("ESCDELAY", str(delay))
 
 
-def pretty_ts(ts: int):
+def pretty_ts(ts: int) -> str:
     now = datetime.utcnow()
     diff = now - datetime.utcfromtimestamp(ts)
     second_diff = diff.seconds

--- a/tg/utils.py
+++ b/tg/utils.py
@@ -216,3 +216,37 @@ class suspend:
 
 def set_shorter_esc_delay(delay=25):
     os.environ.setdefault("ESCDELAY", str(delay))
+
+
+def pretty_ts(ts):
+    now = datetime.utcnow()
+    diff = now - datetime.utcfromtimestamp(ts)
+    second_diff = diff.seconds
+    day_diff = diff.days
+    log.info("diff:: %s, %s, %s", ts, second_diff, day_diff)
+
+    if day_diff < 0:
+        return ""
+
+    if day_diff == 0:
+        if second_diff < 10:
+            return "just now"
+        if second_diff < 60:
+            return f"{second_diff} seconds ago"
+        if second_diff < 120:
+            return "a minute ago"
+        if second_diff < 3600:
+            return f"{int(second_diff / 60)} minutes ago"
+        if second_diff < 7200:
+            return "an hour ago"
+        if second_diff < 86400:
+            return f"{int(second_diff / 3600)} hours ago"
+    if day_diff == 1:
+        return "Yesterday"
+    if day_diff < 7:
+        return f"{day_diff} days ago"
+    if day_diff < 31:
+        return f"{int(day_diff / 7)} weeks ago"
+    if day_diff < 365:
+        return f"{int(day_diff / 30)} months ago"
+    return f"{int(day_diff / 365)} years ago"


### PR DESCRIPTION
This patch introduces new status panel at the top of the app window.
Chat status panel shows connection state (like official mobile client does) and also will allow user to distinguish archived chats in the future.
Msg status panel show chat info, depending on it's type:
- private: show user name and it's online status
- group: show group name and members
- supergroup and channel: same as group
- secret: not supported for now

Also, there this status panels allow users to see chat actions: `typing...`, `sending voice note...`, etc.


Concerns:
- Whether we should we show chat type (private, group, channel, supergroup, secrete).
  I think it might be useful, especially secret chats should be marked, but official client does not distinguishes other types visually.
- Whether we should show all types of chat actions in chat panel.
  `sending voice note...` might be quite long. We could allow users to customize it to make it smaller, cause chat flags growing... 

P.S. It's a draft, there is some refactoring needed.