### PR TITLE
Fix invalid width count when resizing and terminal width is uneven

### DIFF
--- a/tg/controllers.py
+++ b/tg/controllers.py
@@ -747,8 +747,10 @@ class Controller:
         self.view.stdscr.erase()
         self.view.stdscr.noutrefresh()
 
-        self.view.chats.resize(rows, cols, self.chat_size)
-        self.view.msgs.resize(rows, cols, 1 - self.chat_size)
+        chat_width = round(cols * self.chat_size)
+        msg_width = cols - chat_width
+        self.view.chats.resize(rows, cols, chat_width)
+        self.view.msgs.resize(rows, cols, msg_width)
         self.view.status.resize(rows, cols)
         self.render()
 

--- a/tg/views.py
+++ b/tg/views.py
@@ -137,9 +137,9 @@ class ChatView:
         self._refresh = self.win.refresh
         self.model = model
 
-    def resize(self, rows: int, cols: int, p: float = 0.25) -> None:
+    def resize(self, rows: int, cols: int, width: int) -> None:
         self.h = rows - 1
-        self.w = round(cols * p)
+        self.w = width
         self.win.resize(self.h, self.w)
 
     def _msg_color(self, is_selected: bool = False) -> int:
@@ -278,9 +278,9 @@ class MsgView:
             "messageSendingStatePending": "pending",
         }
 
-    def resize(self, rows: int, cols: int, p: float = 0.5) -> None:
+    def resize(self, rows: int, cols: int, width: int) -> None:
         self.h = rows - 1
-        self.w = round(cols * p)
+        self.w = width
         self.x = cols - self.w
         self.win.resize(self.h, self.w)
         self.win.mvwin(0, self.x)


### PR DESCRIPTION
When terminal size is uneven, e.g. 167 and width ratio equals 0.5 then we can notice glitch
167*0.5 = 83.5
round(167 * 0.5) = 84
84 + 84 = 168
As you can see, width of both panels (chat and msg) count incorrectly which leads to text overlap.
