### PR TITLE
Fix drawing glitch with chat vertical separator

### DIFF
--- a/tg/utils.py
+++ b/tg/utils.py
@@ -196,8 +196,9 @@ def truncate_to_len(string: str, width: int) -> str:
 
     for char in string:
         cur_len += 2 if unicodedata.east_asian_width(char) in "WF" else 1
-        if cur_len < width:
-            out_string += char
+        out_string += char
+        if cur_len >= width:
+            break
     return out_string
 
 


### PR DESCRIPTION
#96
Implemented correct double width character count which fixes error with failed msg draw when emojies didn't count correctly.
Fixed glitch by drawing flags fristly and after that text message which made curses or terminal count correctly offset.
