### PR TITLE
Fix hang when opened external app and resizing terminal

### DIFF
--- a/tg/controllers.py
+++ b/tg/controllers.py
@@ -1,4 +1,3 @@
-import curses
 import logging
 import os
 import shlex
@@ -757,8 +756,7 @@ class Controller:
                 log.exception("Error happend in key handle loop")
 
     def resize_handler(self, signum: int, frame: Any) -> None:
-        curses.endwin()
-        self.view.stdscr.refresh()
+        self.view.resize_handler()
         self.resize()
 
     def resize(self) -> None:
@@ -777,7 +775,7 @@ class Controller:
         self.view.chats.resize(rows, cols, chat_width)
         self.view.msgs.resize(rows, cols, msg_width)
         self.view.status.resize(rows, cols)
-        self.render()
+        self._render()
 
     def draw(self) -> None:
         while self.is_running:

--- a/tg/utils.py
+++ b/tg/utils.py
@@ -236,6 +236,7 @@ class suspend:
     def __enter__(self) -> "suspend":
         for view in (self.view.chats, self.view.msgs, self.view.status):
             view._refresh = view.win.noutrefresh
+        self.view.resize_handler = self.view.resize_mock
         curses.echo()
         curses.nocbreak()
         self.view.stdscr.keypad(False)
@@ -251,6 +252,7 @@ class suspend:
     ) -> None:
         for view in (self.view.chats, self.view.msgs, self.view.status):
             view._refresh = view.win.refresh
+        self.view.resize_handler = self.view.resize
         curses.noecho()
         curses.cbreak()
         self.view.stdscr.keypad(True)

--- a/tg/views.py
+++ b/tg/views.py
@@ -57,6 +57,14 @@ class View:
         self.msgs = msg_view
         self.status = status_view
         self.max_read = 2048
+        self.resize_handler = self.resize
+
+    def resize_mock(self) -> None:
+        pass
+
+    def resize(self) -> None:
+        curses.endwin()
+        self.stdscr.refresh()
 
     def get_keys(self) -> Tuple[int, str]:
         keys = repeat_factor = ""


### PR DESCRIPTION
Reproduce:
1. Open any chat
2. Open external program, e.g. vim to enter long msg
3. Resize terminal

Now everything will be hung and the only way is to kill it