### PR TITLE
basic input editing

### DIFF
--- a/tg/utils.py
+++ b/tg/utils.py
@@ -211,6 +211,22 @@ def truncate_to_len(string: str, width: int) -> str:
     return out_string
 
 
+def word_forth(string: str) -> int:
+    """Returns the index of the first word"""
+    ind = string.find(' ')
+    if ind < 0:
+        return len(string)
+    s = string[ind:].lstrip()
+    return ind + len(string[ind:]) - len(s)
+
+
+def word_back(string: str) -> int:
+    """Returns the index of the last word"""
+    s = string.rstrip()
+    prev_space = s.rfind(' ')
+    return prev_space + 1
+
+
 def copy_to_clipboard(text: str) -> None:
     subprocess.run(
         config.COPY_CMD, universal_newlines=True, input=text, shell=True


### PR DESCRIPTION
Basic text manipulation when using `StatusView`' input. Key bindings similar to those in Vim's command line:
- `arrows left/right`: move by chars
- `ctrl+left/right`: move by words
- `ctrl+h`, `backspace`: delete previous char
- `delete`: delete char under cursor (if at the end of line - delete previous char)
- `ctrl+w`: delete previous word
- `ctrl+delete`: delete word after cursor
- `ctrl+u`: delete from cursor to the beginning of line
- `home`, `ctrl+b`: go to the beginning of line
- `end`, `ctrl+e`: go the end of line

Navigation/editing attempts to be wide-charactare aware.
Some key bindings (e.g., ctrl+arrows) might not work in some terminal emulators (`curses` returns different terminal-dependent values for keys). Current version tested in Linux only, with `kitty`, `terminator`, `alacritty`.
