### PR TITLE
Fix sticker view

### DIFF
--- a/tg/msg.py
+++ b/tg/msg.py
@@ -48,6 +48,8 @@ class MsgProxy:
                 doc = doc[field]
             else:
                 doc = doc.get(field)
+            if "file" in doc:
+                return doc["file"]
             if doc is None:
                 return {}
         return doc


### PR DESCRIPTION
See #236 . The filepath of a sticker is stored in the key "file".