### PR TITLE
Made selection bold and underlined instead of reverse colour

### DIFF
--- a/tg/views.py
+++ b/tg/views.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union, cast
 from _curses import window  # type: ignore
 
 from tg import config
-from tg.colors import bold, cyan, get_color, magenta, reverse, white, yellow
+from tg.colors import bold, cyan, get_color, magenta, reverse, underline, white, yellow
 from tg.models import Model, UserModel
 from tg.msg import MsgProxy
 from tg.tdlib import ChatType, get_chat_type, is_group
@@ -173,13 +173,13 @@ class ChatView:
     def _msg_color(self, is_selected: bool = False) -> int:
         color = get_color(white, -1)
         if is_selected:
-            return color | reverse
+            return color | underline | bold
         return color
 
     def _unread_color(self, is_selected: bool = False) -> int:
         color = get_color(magenta, -1)
         if is_selected:
-            return color | reverse
+            return color | underline | bold
         return color
 
     def _chat_attributes(
@@ -192,7 +192,7 @@ class ChatView:
             self._msg_color(is_selected),
         )
         if is_selected:
-            return tuple(attr | reverse for attr in attrs)
+            return tuple(attr | underline | bold for attr in attrs)
         return attrs
 
     def draw(
@@ -593,7 +593,7 @@ class MsgView:
         )
 
         if is_selected:
-            return tuple(attr | reverse for attr in attrs)
+            return tuple(attr | underline | bold for attr in attrs)
         return attrs
 
     def _parse_msg(self, msg: MsgProxy) -> str:


### PR DESCRIPTION
I found the default selection colouring (reverse colour) too invasive and often harmed reading contrast. This one uses bold and underline and is more subtle. 

Should fix issue #263