### PR TITLE
implementing the ability to edit messages rather than cancel them unxpectedly on certain keypresses 

### DIFF
--- a/tg/controllers.py
+++ b/tg/controllers.py
@@ -318,7 +318,7 @@ class Controller:
             self.present_info("Can't send msg in this chat")
             return
         self.tg.send_chat_action(chat_id, ChatAction.chatActionTyping)
-        if msg := self.view.status.get_input():
+        if msg := self.view.status.get_input(view=self.view):
             self.model.send_message(text=msg)
             self.present_info("Message sent")
         else:


### PR DESCRIPTION
This implements a solution for #293, albeit a bit of a hacky one: left arrow does the same as backspace, other control characters open up the editor for further message editing