### PR TITLE
Add Arabic/Persian text reshaping and BiDi support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,12 @@ license = { text = "Unlicense" }
 readme = "readme.md"
 urls = { homepage = "https://github.com/paul-nameless/tg", repository = "https://github.com/paul-nameless/tg" }
 requires-python = ">=3.9,<4.0.0"
-dependencies = ["python-telegram==0.19.0", "standard-mailcap (>=3.13.0)"]
+dependencies = [
+  "python-telegram==0.19.0",
+  "standard-mailcap>=3.13.0",
+  "arabic-reshaper>=3.0.0",
+  "python-bidi>=0.6.0",
+]
 
 [tool.poetry]
 name = "tg"

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ Telegram terminal client.
 - [X] list contacts
 - [X] show user status
 - [X] secret chats
+- [X] Arabic/Persian text rendering (reshaping + BiDi)
 - [ ] search
 - [ ] bots (bot keyboard)
 
@@ -61,7 +62,6 @@ pip3 install tg
 tg
 ```
 
-
 ### From sources
 
 This option is recommended for development:
@@ -69,7 +69,6 @@ This option is recommended for development:
 ```sh
 git clone https://github.com/paul-nameless/tg.git
 cd tg
-pip install python-telegram
 pip install .
 tg
 ```
@@ -193,6 +192,9 @@ FILE_PICKER_CMD = "ranger --choosefile={file_path}"
 MAILCAP_FILE = os.path.expanduser("~/.config/mailcap")
 
 DOWNLOAD_DIR = os.path.expanduser("~/Downloads/")  # copy file to this dir
+
+# Set to False to disable Arabic/Persian text reshaping and BiDi reordering.
+USE_RTL_LAYOUT = True
 ```
 
 ### Mailcap file
@@ -217,6 +219,21 @@ text/plain; less "%s"
 text/*; vim "%s"
 ```
 
+
+## RTL support (Arabic/Persian)
+
+Arabic and Persian text requires two processing steps before a terminal can display it correctly:
+
+1. **Letter reshaping** — Arabic/Persian letters change shape depending on their neighbours (isolated, initial, medial, final forms). Without reshaping, every character appears in its isolated form.
+2. **BiDi reordering** — terminals render text left-to-right, so right-to-left text must be pre-reordered into visual order before being drawn.
+
+Both steps are handled automatically using [arabic-reshaper](https://github.com/mpcabd/python-arabic-reshaper) and [python-bidi](https://github.com/MeirKriheli/python-bidi), which are included as standard dependencies. Mixed LTR/RTL text (e.g. a Persian sentence with an English URL) is handled correctly — only the RTL segments are reordered.
+
+To disable RTL rendering, add the following to `~/.config/tg/conf.py`:
+
+```python
+USE_RTL_LAYOUT = False
+```
 
 ## Keybindings
 

--- a/tg/config.py
+++ b/tg/config.py
@@ -103,6 +103,9 @@ CHAT_FLAGS: Dict[str, str] = {}
 
 MSG_FLAGS: Dict[str, str] = {}
 
+# Set to False to disable Arabic/Persian text reshaping and BiDi layout support.
+USE_RTL_LAYOUT = True
+
 ICON_PATH = os.path.join(os.path.dirname(__file__), "resources", "tg.png")
 
 URL_VIEW = "urlview"

--- a/tg/utils.py
+++ b/tg/utils.py
@@ -18,12 +18,42 @@ from subprocess import CompletedProcess
 from types import TracebackType
 from typing import Any, Dict, Optional, Tuple, Type
 
+import arabic_reshaper
 import mailcap
+from bidi.algorithm import get_display as _bidi_get_display
 
 from tg import config
 
 log = logging.getLogger(__name__)
 units = {"B": 1, "KB": 10**3, "MB": 10**6, "GB": 10**9, "TB": 10**12}
+
+# RTL characters: Arabic Letter (AL), Right-to-Left (R), Arabic Number (AN)
+_RTL_BIDIR_CATS = frozenset(("R", "AL", "AN"))
+
+
+def _has_rtl(text: str) -> bool:
+    return any(unicodedata.bidirectional(c) in _RTL_BIDIR_CATS for c in text)
+
+
+def reshape_rtl(text: str) -> str:
+    """
+    Reshape Arabic/Persian characters and apply the BiDi visual-order algorithm
+    so that terminals (which render left-to-right) display RTL text correctly.
+
+    Works line-by-line so mixed LTR/RTL multiline strings are handled properly.
+    Lines with no RTL characters are returned as-is, so pure LTR text is
+    unaffected. Set USE_RTL_LAYOUT = False in ~/.config/tg/conf.py to disable.
+    """
+    if not config.USE_RTL_LAYOUT:
+        return text
+    lines = text.split("\n")
+    result = []
+    for line in lines:
+        if _has_rtl(line):
+            result.append(_bidi_get_display(arabic_reshaper.reshape(line)))
+        else:
+            result.append(line)
+    return "\n".join(result)
 
 
 class LogWriter:

--- a/tg/views.py
+++ b/tg/views.py
@@ -9,7 +9,7 @@ from tg.colors import bold, cyan, get_color, magenta, reverse, white, yellow
 from tg.models import Model, UserModel
 from tg.msg import MsgProxy
 from tg.tdlib import ChatType, get_chat_type, is_group
-from tg.utils import get_color_by_str, num, string_len_dwc, truncate_to_len
+from tg.utils import get_color_by_str, num, reshape_rtl, string_len_dwc, truncate_to_len
 
 log = logging.getLogger(__name__)
 
@@ -204,7 +204,7 @@ class ChatView:
         for i, chat in enumerate(chats, 1):
             is_selected = i == current + 1
             date = get_date(chat)
-            title = chat["title"]
+            title = reshape_rtl(chat["title"])
             offset = 0
 
             last_msg_sender, last_msg = self._get_last_msg_data(chat)
@@ -567,7 +567,7 @@ class MsgView:
             ):
                 status = f"{supergroup['member_count']} subscribers"
 
-        return f"{chat['title']}: {status}".center(self.w)[: self.w]
+        return f"{reshape_rtl(chat['title'])}: {status}".center(self.w)[: self.w]
 
     def _msg_attributes(self, is_selected: bool, user: str) -> Tuple[int, ...]:
         attrs = (
@@ -613,7 +613,7 @@ def get_date(chat: Dict[str, Any]) -> str:
 
 def parse_content(msg: MsgProxy, users: UserModel) -> str:
     if msg.is_text:
-        return msg.text_content.replace("\n", " ")
+        return reshape_rtl(msg.text_content.replace("\n", " "))
 
     content = msg["content"]
     _type = content["@type"]


### PR DESCRIPTION
## Problem

Arabic and Persian messages are unreadable in the terminal client. Two issues compound each other:

1. **Wrong letter forms** — Arabic/Persian letters are contextual: each has up to four shapes depending on its neighbours (isolated, initial, medial, final). Without reshaping, every character is displayed in its isolated form, producing disconnected blobs.
2. **Wrong direction** — terminals render left-to-right, but Persian/Arabic is right-to-left. Without the Unicode Bidirectional Algorithm the words appear in reverse reading order.

## Solution

- **`tg/utils.py`** — adds `reshape_rtl(text)` which uses `arabic-reshaper` to fix letter forms and `python-bidi` to reorder characters into the visual order that LTR terminals expect. Works line-by-line so mixed LTR/RTL strings are handled correctly. Lines with no RTL characters are returned unchanged, so pure LTR text is completely unaffected.
- **`tg/views.py`** — applies `reshape_rtl()` to message text (`parse_content`), chat-list titles (`ChatView.draw`), and the message-panel title bar (`MsgView._msg_title`).
- **`tg/config.py`** — adds `USE_RTL_LAYOUT = True`. Users who don't need RTL can set this to `False` in `~/.config/tg/conf.py`.
- **`pyproject.toml`** — adds `arabic-reshaper` and `python-bidi` as standard dependencies. Both libraries are small and Telegram has a large Arabic/Persian user base, so RTL support is on by default with no extra install steps.

## Testing

```python
from tg.utils import reshape_rtl

reshape_rtl('سلام دنیا')      # Persian — reshaped & reordered ✓
reshape_rtl('Hello World')    # English — unchanged ✓
reshape_rtl('hello سلام')     # Mixed  — only the Persian segment is reordered ✓
```